### PR TITLE
Fix sls-offline cookie header typo

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -6,14 +6,14 @@ provider:
   stage: dev
   region: us-east-1
 
-package:
-  exclude:
-    - ./**
-  include:
-    - src/api/**
-    - node_modules/jsonwebtoken
-    - node_modules/universal-cookie
-    - node_modules/dotenv-load
+# package:
+#   exclude:
+#     - ./**
+#   include:
+#     - src/api/**
+#     - node_modules/jsonwebtoken
+#     - node_modules/universal-cookie
+#     - node_modules/dotenv-load
 
 functions:
   auth:

--- a/src/api/lambda.js
+++ b/src/api/lambda.js
@@ -1,3 +1,5 @@
+/* eslint no-console: ["error", { allow: ["error","info"] }] */
+
 const { retrieveAuthCookie, verifyJwt, signJwt } = require('./actions');
 const {
   authedResponse,
@@ -26,12 +28,15 @@ module.exports.auth = async (event) => {
 
 module.exports.verify = async (event) => {
   const secret = process.env.YVC_JWT_SECRET_KEY;
-  const userToken = retrieveAuthCookie(event.headers.cookie, userCookieKey);
+  // serverless-offline seems to provide a lowercase 'cookie' header. Lambda capitalises it.
+  const cookies = event.headers.Cookie || event.headers.cookie;
+  const userToken = retrieveAuthCookie(cookies, userCookieKey);
 
   try {
     verifyJwt(userToken, secret);
     return verifiedResponse;
   } catch (err) {
+    console.error(err);
     return unauthedResponse;
   }
 };


### PR DESCRIPTION
The serverless-offline plugin uses a cookie header value of cookie, whilst AWS uses Cookie. This patch allows either to work.